### PR TITLE
Keep long URLs, code, and tables from overflowing hack descriptions on mobile

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -276,6 +276,11 @@ html { scroll-padding-top: var(--anchor-offset); }
   --tw-prose-code: var(--foreground);
   --tw-prose-hr: var(--border);
   --tw-prose-captions: color-mix(in oklab, var(--foreground) 70%, transparent);
+  overflow-wrap: anywhere;
+}
+
+.prose pre {
+  overflow-x: auto;
 }
 
 .prose * {
@@ -365,6 +370,8 @@ html { scroll-padding-top: var(--anchor-offset); }
 
 .prose table {
   @apply my-6 w-full text-sm text-left text-foreground/70;
+  display: block;
+  overflow-x: auto;
 }
 .prose table th, .prose table td {
   @apply px-6 py-4 border border-zinc-400/30 dark:border-zinc-600/50;

--- a/src/app/hack/[slug]/page.tsx
+++ b/src/app/hack/[slug]/page.tsx
@@ -477,7 +477,7 @@ export default async function HackDetail({ params }: HackDetailProps) {
       </div>
 
       <div className="mt-6 px-6 flex flex-col gap-6 lg:grid lg:grid-cols-[minmax(0,1fr)_260px]">
-        <div className="space-y-6 lg:min-w-[640px]">
+        <div className="min-w-0 space-y-6 lg:min-w-[640px]">
           <Gallery images={images} title={hack.title} />
 
           {patchId && patchCreatedAt && (


### PR DESCRIPTION
## Summary

Long URLs, fenced code, and wide tables in a hack description have no wrap points, so on phones they stretch past the card and push the page sideways.

Descriptions now wrap unbreakable text, scroll code and tables inside the card, and the main column can shrink instead of growing with that content.

## Test plan

- [x] Open a hack page on a phone-width viewport whose description includes a long URL — the URL wraps inside the About card
- [x] Same page (or another) with a fenced code block — the block stays in the card and scrolls horizontally
- [x] Same with a wide markdown table — the table stays in the card and scrolls horizontally
- [x] Confirm changelog markdown on the hack page and the changelog route behave the same
- [x] Desktop layout still looks unchanged


Made with [Cursor](https://cursor.com)