### PR TITLE
Keep patched ROM downloads from being saved as .gba.txt

### DIFF
--- a/src/utils/patching/save.ts
+++ b/src/utils/patching/save.ts
@@ -48,7 +48,7 @@ function createBlobSink(fileName: string): OutputSink {
       chunks.push(asArrayBufferView(bytes));
     },
     async close() {
-      triggerBlobDownload(new Blob(chunks), fileName);
+      triggerBlobDownload(new Blob(chunks, { type: "application/octet-stream" }), fileName);
     },
     async abort() {
       chunks.length = 0;


### PR DESCRIPTION
## Summary
Users on Safari and Android Chrome have been getting patched ROMs as `.gba.txt` even though the binary was fine. The download blob had no MIME type, so those browsers treated it as text and appended `.txt`.

This marks the blob as `application/octet-stream` so the `.gba` name is kept.

## Test plan
- [ ] On Android Chrome, Agree and Patch an xdelta GBA hack and confirm the file is `.gba` (not `.gba.txt`)
- [x] On Safari/iOS, same check
- [x] On desktop Chrome, confirm the save picker / download still works
- [x] Rename-and-play is unnecessary if the extension is already correct; the ROM should still boot


Made with [Cursor](https://cursor.com)